### PR TITLE
Configure Render static site deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,11 @@
+services:
+  - type: static_site
+    name: static_site
+    rootDir: frontend
+    buildCommand: npm install && npm run build
+    staticPublishPath: dist
+    envVars:
+      - key: VITE_API_BASE_URL
+        sync: false
+      - key: ANALYTICS_KEY
+        sync: false


### PR DESCRIPTION
## Summary
- add Render static site service configuration targeting the frontend build output
- ensure the static publish directory references the frontend build output folder
- provide environment variable entries for dashboard-managed secrets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd9dd46554832aa6b329895189f47d